### PR TITLE
Enable LDAPs when SSSD requires it NethServer/dev#5161

### DIFF
--- a/root/etc/e-smith/templates/etc/ejabberd/ejabberd.cfg/55AuthConf
+++ b/root/etc/e-smith/templates/etc/ejabberd/ejabberd.cfg/55AuthConf
@@ -1,19 +1,2 @@
-{
-  use NethServer::SSSD;
-
-  my $sssd = new NethServer::SSSD();
-
-  if ($sssd->host() ) {
-      $OUT .= "{auth_method, [ldap]}.\n";
-      $OUT .= "{ldap_servers, [\"".$sssd->host()."\"]}.\n";
-      $OUT .= "{ldap_port, ".$sssd->port()."}.\n";
-      $OUT .= "{ldap_base, \"".$sssd->baseDN()."\"}.\n";
-      $OUT .= "{ldap_rootdn, \"".$sssd->bindDN()."\"}.\n";
-      $OUT .= "{ldap_password, \"".$sssd->bindPassword()."\"}.\n";
-  }
-
-  if ($sssd->isAD()) {
-      $OUT .= "{ldap_uids, [\"sAMAccountName\"]}.\n";
-  }
-
-}
+\{auth_method, [external]\}.
+\{extauth_program, "/usr/libexec/nethserver/ejabberd-auth"\}.

--- a/root/etc/e-smith/templates/etc/ejabberd/ejabberd.cfg/55AuthConf
+++ b/root/etc/e-smith/templates/etc/ejabberd/ejabberd.cfg/55AuthConf
@@ -1,2 +1,8 @@
+%
+% 55AuthConf
+%
 \{auth_method, [external]\}.
 \{extauth_program, "/usr/libexec/nethserver/ejabberd-auth"\}.
+\{extauth_instances, 3\}.
+
+

--- a/root/etc/e-smith/templates/etc/ejabberd/ejabberd.cfg/85Modules
+++ b/root/etc/e-smith/templates/etc/ejabberd/ejabberd.cfg/85Modules
@@ -39,11 +39,30 @@ HERE
     $OUT .= ${DomainName};
     $OUT .= '"}]},';
     $OUT .= "\n";
- 
-my $sssd = new NethServer::SSSD();
+
+    use NethServer::SSSD;
+    my $sssd = NethServer::SSSD->new();
+
+my $ldap_host = $sssd->host();
+my $ldap_port = $sssd->port();
+my $ldap_encrypt = 'none';
+my $ldap_rootdn = $sssd->bindDN();
+my $ldap_password_escaped = $sssd->bindPassword(); $ldap_password_escaped =~ s/\"/\\"/g;
+
+if($sssd->ldapURI =~ /^ldaps/) {
+    $ldap_encrypt = 'tls';
+}
 
 $OUT.= "  {mod_shared_roster_ldap,[\n";
+$OUT.= "     {ldap_servers, [\"$ldap_host\"]},\n";
+$OUT.= "     {ldap_port, $ldap_port},\n";
+$OUT.= "     {ldap_encrypt, $ldap_encrypt},\n";
 $OUT.= "     {ldap_base, \"".$sssd->baseDN()."\"},\n";
+
+if($sssd->isAD() || $sssd->bindDN()) {
+    $OUT .= "     {ldap_rootdn, \"$ldap_rootdn\"},\n";
+    $OUT .= "     {ldap_password, \"$ldap_password_escaped\"},\n";
+}
 
 if ($sssd->isAD()) {
 #
@@ -51,11 +70,11 @@ if ($sssd->isAD()) {
 #
 $OUT .= <<HERE
      {ldap_groupattr, "sAMAccountName"},
-     {ldap_groupdesc, ""},
+     {ldap_groupdesc, "cn"},
      {ldap_memberattr, "sAMAccountName"},
      {ldap_memberattr_format, "%u"},
      {ldap_useruid, "sAMAccountName"},
-     {ldap_userdesc, "displayName"},
+     {ldap_userdesc, "cn"},
      {ldap_rfilter, "(objectClass=group)"},
      {ldap_gfilter, "(objectClass=user)"},
      {ldap_ufilter, "(&(objectClass=user)(sAMAccountName=%u))"},

--- a/root/usr/libexec/nethserver/ejabberd-auth
+++ b/root/usr/libexec/nethserver/ejabberd-auth
@@ -1,0 +1,53 @@
+#!/usr/bin/perl
+
+#
+# Copyright (C) 2016 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+use strict;
+
+my $result = 0;
+my $buf = '';
+
+while(1)
+{
+    my $nread = sysread STDIN, $buf, 2;
+    if($nread != 2) {
+        exit(0);
+    }
+
+    my $len = unpack "n", $buf;
+
+    $nread = sysread STDIN, $buf, $len;
+
+    my ($op, $user, $domain, $password) = split /:/,$buf;
+
+    if($op eq 'auth') {
+        open(my $ah, '| /usr/libexec/nethserver/pam-authenticate');
+        print $ah "$user\@$domain\n$password\n";
+        $result = close($ah);
+    } elsif($op eq 'isuser') {
+        $result = getpwnam("$user\@$domain");
+    } elsif($op eq 'setpass') {
+        $result = 0; # not supported
+    }
+
+    my $out = pack "nn", 2, ($result ? 1 : 0);
+    syswrite STDOUT, $out;
+}


### PR DESCRIPTION
- Use "ejabberd-auth" external authentication script for password
  validation. The script authenticates credentials with PAM library.

- Get the list of users with LDAPs when required, otherwise try to
  bind anonymously.

NOTE: a remote LDAP server requires STARTTLS to protect password binds, but
ejabberd does not support it.

NethServer/dev#5161