### PR TITLE
Fix password authentication

### DIFF
--- a/root/usr/libexec/nethserver/ejabberd-auth
+++ b/root/usr/libexec/nethserver/ejabberd-auth
@@ -36,7 +36,7 @@ while(1)
 
     $nread = sysread STDIN, $buf, $len;
 
-    my ($op, $user, $domain, $password) = split /:/,$buf;
+    my ($op, $user, $domain, $password) = split(/:/, $buf, 4);
 
     if($op eq 'auth') {
         open(my $ah, '| /usr/libexec/nethserver/pam-authenticate');


### PR DESCRIPTION
If the password contains a double colon ":" the Perl `split()` function truncates it preventing the PAM auth helper to succeed.

https://github.com/NethServer/dev/issues/5931