### PR TITLE
Clear cache when the user password is modified locally

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -122,3 +122,10 @@ $event = 'post-restore-data';
 
 event_actions($event, 'nethserver-ejabberd-restore' => 50);
 event_services($event, 'ejabberd' => 'restart');
+
+#--------------------------------------------------
+# password-modify event
+#--------------------------------------------------
+event_actions('password-modify', qw(
+              nethserver-ejabberd-clearCache 90
+));

--- a/root/etc/e-smith/events/actions/nethserver-ejabberd-clearCache
+++ b/root/etc/e-smith/events/actions/nethserver-ejabberd-clearCache
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2019 Nethesis S.r.l.
+# http://www.nethesis.it - support@nethesis.it
+# 
+# This script is part of NethServer.
+# 
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+# 
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Test if the service is running before to clear cache
+/usr/bin/systemctl is-active --quiet ejabberd
+if [[ $? != 0 ]]; then
+    echo '[WARNING] Ejabberd is not running, clear cache is not possible'
+    exit 0
+fi
+
+/opt/ejabberd-*/bin/ejabberdctl clear_cache >/dev/null


### PR DESCRIPTION
https://community.nethserver.org/t/ejabberd-user-password-does-not-work-when-we-change-the-password-in-nethgui-and-cockpit-solution-already-said-several-days-ago/14153/