### PR TITLE
Update 70C2sS2SConf

### DIFF
--- a/root/etc/e-smith/templates/etc/ejabberd/ejabberd.yml/70C2sS2SConf
+++ b/root/etc/e-smith/templates/etc/ejabberd/ejabberd.yml/70C2sS2SConf
@@ -3,7 +3,7 @@ shaper:
   normal: {${ejabberd}{'ShaperNormal'} || '500000';}
   fast: {${ejabberd}{'ShaperFast'} || '1000000';}
 
-max_fsm_queue: 1000
+max_fsm_queue: 5000
 
 shaper_rules:
   max_user_sessions: 10

--- a/root/etc/e-smith/templates/etc/ejabberd/ejabberd.yml/70C2sS2SConf
+++ b/root/etc/e-smith/templates/etc/ejabberd/ejabberd.yml/70C2sS2SConf
@@ -3,7 +3,7 @@ shaper:
   normal: {${ejabberd}{'ShaperNormal'} || '500000';}
   fast: {${ejabberd}{'ShaperFast'} || '1000000';}
 
-max_fsm_queue: 5000
+max_fsm_queue: 10000
 
 shaper_rules:
   max_user_sessions: 10


### PR DESCRIPTION
Updating max queue to align with ejabberd suggested default. This value is too low and can cause rapid disconnects when joining large MUCs.