### PR TITLE
Force to use tls if startTls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Properties:
 * *ModMamPurgeDBInterval*: Remove messages older than X days, default is ``30``
 * *ShaperFast*: Download speed limit in bytes/second for admin users, default is ``1000000``
 * *ShaperNormal*: Download speed limit in bytes/second for users, default is ``500000``
-
+* *LdapTlsPortOverride*: The user roster LDAP client does not support STARTTLS. If the system account provider is configured with STARTTLS, configure the user roster LDAP client to use this TCP port number during connections instead (default is port 636).
 
 When enabled, web-based administration interface listens on 5280 port.
 You need a user inside jabberadmins group to login.

--- a/root/etc/e-smith/templates/etc/ejabberd/ejabberd.yml/85ModulesRoasterLdap
+++ b/root/etc/e-smith/templates/etc/ejabberd/ejabberd.yml/85ModulesRoasterLdap
@@ -15,6 +15,10 @@
         $ldap_encrypt = 'tls';
     }
 
+    if ($sssd->startTls()) {
+        $ldap_encrypt = 'tls';
+        $ldap_port = $ejabberd{'LdapTlsPortOverride'} || '636';
+    }
 
     $config{'ldap_servers'} = $ldap_host;
     $config{'ldap_port'} = $ldap_port;


### PR DESCRIPTION
The remote authentication to SAMBA AD is broken we must force the TLS and the use of port 636 if we detect that starttls is used with AD

```
@eldap:report_bind_failure:988 LDAP bind failed on nsdc-ns7loc12.ad.nethservertest.org:389
Reason: strongAuthRequired
```

Ejabberd don't use the protocol startTls, the TLS encryption is 'none|tls', only ldap over ssl is supported, if startTls is detected then we must force the tls encryption on a port you can customize.

https://github.com/NethServer/dev/issues/6399