### PR TITLE
Avoid to fail the rpm build

### DIFF
--- a/nethserver-ejabberd.spec
+++ b/nethserver-ejabberd.spec
@@ -69,7 +69,7 @@ mkdir -p %{buildroot}/%{_localstatedir}/lib/nethserver/ejabberd/upload
 %systemd_preun ejabberd.service
 
 %postun
-%systemd_postun
+%systemd_postun ejabberd.service
 
 
 %changelog


### PR DESCRIPTION
We have  something broken in the spec file, now the usage of` %systemd_postun` must be done with the name of the service to manage

this is the error

```
╰─➤  make-rpms *.spec
make-rpms [INFO] git describe: 1.8.2 2 g62fa10f
error: The %systemd_postun macro requires some arguments
Traceback (most recent call last):
  File "/usr/bin/spectool", line 441, in <module>
    exit(main())
  File "/usr/bin/spectool", line 366, in main
    spec = Spec(path)
  File "/usr/bin/spectool", line 207, in __init__
    self.spec = rpm.spec(self.path)
ValueError: can't parse specfile

error: The %systemd_postun macro requires some arguments
Traceback (most recent call last):
  File "/usr/bin/spectool", line 441, in <module>
    exit(main())
  File "/usr/bin/spectool", line 366, in main
    spec = Spec(path)
  File "/usr/bin/spectool", line 207, in __init__
    self.spec = rpm.spec(self.path)
ValueError: can't parse specfile

basename: missing operand
Try 'basename --help' for more information.
Cleaning up temporary files..
removed './.tmpO2liP99.spec'
removed './.tmpWQleDJI.gitlog'
```

It seems something new, but I am sure it makes sense

https://github.com/NethServer/dev/issues/6400